### PR TITLE
Optimize memory usage of removeSliceDuplicatesTimeOnSortedSlice

### DIFF
--- a/job.go
+++ b/job.go
@@ -493,13 +493,17 @@ func (o oneTimeJobDefinition) setup(j *internalJob, _ *time.Location, now time.T
 }
 
 func removeSliceDuplicatesTimeOnSortedSlice(times []time.Time) []time.Time {
-	ret := make([]time.Time, 0, len(times))
-	for i, t := range times {
-		if i == 0 || t != times[i-1] {
-			ret = append(ret, t)
+	if len(times) == 0 {
+		return times
+	}
+	j := 0
+	for i := 1; i < len(times); i++ {
+		if times[i] != times[j] {
+			j++
+			times[j] = times[i]
 		}
 	}
-	return ret
+	return times[:j+1]
 }
 
 // OneTimeJobStartAtOption defines when the one time job is run

--- a/job_test.go
+++ b/job_test.go
@@ -724,3 +724,67 @@ func TestTimeFromAtTime(t *testing.T) {
 		})
 	}
 }
+
+func TestRemoveSliceDuplicatesTimeOnSortedSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []time.Time
+		expected []time.Time
+	}{
+		{
+			name:     "empty slice",
+			input:    []time.Time{},
+			expected: []time.Time{},
+		},
+		{
+			name: "only one",
+			input: []time.Time{
+				time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			expected: []time.Time{
+				time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "no duplicates",
+			input: []time.Time{
+				time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC),
+			},
+			expected: []time.Time{
+				time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "with duplicates",
+			input: []time.Time{
+				time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC),
+			},
+			expected: []time.Time{
+				time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name: "all duplicates",
+			input: []time.Time{
+				time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+				time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			expected: []time.Time{
+				time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := removeSliceDuplicatesTimeOnSortedSlice(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Motivation
---
Optimizing memory usage in your `removeSliceDuplicatesTimeOnSortedSlice` function involves reducing the number of allocations and avoiding excessive appending.

**Before:**
![image](https://github.com/user-attachments/assets/ff63e3e4-f50f-4298-a550-6f4d84e55e3c)

**After:**
TBD

Summary
---
Instead of creating a new `ret` slice, we reuse the original sorted times slice. Since the input slice is sorted we can use the input slice to hold the result in-place, eliminating the need for an additional slice.